### PR TITLE
Implement Dijkstras Longest Path as a PathStrategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2754,6 +2754,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "heap-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-1.4.1.tgz",
+      "integrity": "sha512-FzbDInEYubylb3um0RFbyqwrFTk/y7i1lGLbvykNazNYqfIZ/bMJ0KN/kQQfu30JZNE7XzHVlGez6F+hdy15Nw=="
+    },
     "hosted-git-info": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,9 +2662,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5900,9 +5900,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.5.tgz",
-      "integrity": "sha512-7L3W+Npia1OCr5Blp4/Vw83tK1mu5gnoIURtT1fUVfQ3Kf8WStWV6NJz0fdoBJZls0KlweruRTLVe6XLafmy5g==",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+      "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
+    "heap-js": "^1.4.1",
     "uuid": "^3.3.3"
   }
 }

--- a/src/graph/adjMatrix.ts
+++ b/src/graph/adjMatrix.ts
@@ -49,11 +49,11 @@ export class AdjacencyMatrix implements GraphIsomorph{
     }
 
     getEdgeCoordinates(): IterableIterator<EdgeCoordinates> {
-        const clonedEdges: EdgeCoordinates[] = [];
+        const edgeCoords: EdgeCoordinates[] = [];
 
         for (let i = 0; i < this.nodes.length; i++) {
             for (let j = 0; j < this.nodes.length; j++) {
-                clonedEdges.push({
+                edgeCoords.push({
                     fro: i,
                     to: j,
                     edge: this.getEdge(i, j),
@@ -61,7 +61,7 @@ export class AdjacencyMatrix implements GraphIsomorph{
             }
         }
 
-        return clonedEdges.values();
+        return edgeCoords.values();
     }
 
     getEdge(fro: number, to: number): Edge {

--- a/src/graph/adjMatrixBuilder.ts
+++ b/src/graph/adjMatrixBuilder.ts
@@ -24,7 +24,7 @@ export class AdjacencyMatrixBuilder {
 
     public withNodes(nodes: IterableIterator<Token>): AdjacencyMatrixBuilder {
         for (const node of nodes) {
-            this.nodes.push(node);
+            this.nodes.push(node.clone());
             this.createNewEdges();
         }
 
@@ -52,7 +52,7 @@ export class AdjacencyMatrixBuilder {
 
         const prevEdge = this.edges[fro][to];
 
-        this.edges[fro][to] = edge;
+        this.edges[fro][to] = edge.clone();
 
         return this;
     }

--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -4,7 +4,7 @@ import {
     Edge,
     PathStrategy,
     ScoreStrategy,
-    MatrixPath
+    Path
 } from './';
 
 import {
@@ -32,8 +32,8 @@ export class Graph {
     }
 
     // TO test `getPaths`, mock isomorph.
-    getPaths(): IterableIterator<MatrixPath> {
-        return this.pathStrategy.findPath(this.isomorph);
+    getPaths(): IterableIterator<Path> {
+        return this.pathStrategy.findPaths(this.isomorph);
     }
 
     getNodes(): IterableIterator<Token> {

--- a/src/graph/graphIsomorph.ts
+++ b/src/graph/graphIsomorph.ts
@@ -18,4 +18,5 @@ export interface GraphIsomorph {
     swapNodes(first: number, second: number): void;
     clone(): GraphIsomorph;
     equalScore(other: GraphIsomorph): boolean;
+    // TODO: isDirectedAcyclic(): boolean;
 }

--- a/src/graph/graphIsomorph.ts
+++ b/src/graph/graphIsomorph.ts
@@ -9,7 +9,7 @@ import {
 
 export interface GraphIsomorph {
     getEdge(fro: number, to: number): Edge;
-    getEdgeCoordinates(fro: number, to: number): IterableIterator<EdgeCoordinates>;
+    getEdgeCoordinates(): IterableIterator<EdgeCoordinates>;
     setEdge(edge: Edge, fro: number, to: number): Edge;
     getNodes(): IterableIterator<Token>;
     getNode(index: number): Token;

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -3,12 +3,10 @@ import {
     GraphIsomorph,
 } from './';
 
-export interface MatrixPath {
-    path: number[];
-}
+export type Path = number[];
 
 export interface PathStrategy {
-    findPath(matrix: GraphIsomorph): IterableIterator<MatrixPath>;
+    findPaths(matrix: GraphIsomorph): IterableIterator<Path>;
 }
 
 export interface ScoreStrategy {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './processor';
 export * from './graph';
+export * from './pathStrategy';
 export * from './scoreStrategy';
 export * from './token';
 export * from './utils';

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -1,0 +1,14 @@
+import {
+    GraphIsomorph,
+    Path,
+    PathStrategy,
+} from '../';
+
+export class DijkstraSinglePath implements PathStrategy {
+    findPaths(isomorph: GraphIsomorph): IterableIterator<Path> {
+        const paths: Path[] = [];
+
+        return paths.values();
+    }
+
+}

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -13,7 +13,7 @@ interface PastMemo {
     cost: number;
 }
 
-export class DijkstraSinglePath implements PathStrategy {
+export class DijkstraLongestPath implements PathStrategy {
     private readonly source = 0;
 
     // Finds max cost to each path from source
@@ -105,7 +105,7 @@ export class DijkstraSinglePath implements PathStrategy {
         return [path].values();
     }
 
-    static create(): DijkstraSinglePath {
-        return new DijkstraSinglePath();
+    static create(): DijkstraLongestPath {
+        return new DijkstraLongestPath();
     }
 }

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -16,7 +16,7 @@ interface PastMemo {
 export class DijkstraSinglePath implements PathStrategy {
     private readonly source = 0;
 
-    // Finds max cost to each path from source (node zero)
+    // Finds max cost to each path from source
     private generateMaxCostMemos(isomorph: GraphIsomorph): PastMemo[] {
         const lenNodes = isomorph.getNumberNodes();
         const destination = lenNodes - 1;

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -25,7 +25,7 @@ export class DijkstraSinglePath implements PathStrategy {
         const neighborHeap = new Heap<number>();
 
         cost[this.source] = { lastNode: -1, cost: 0 };
-        neighborHeap.push(0);
+        neighborHeap.push(this.source);
 
         // Bredth-first, greedy helper
         const searchNeighbors = (index: number): void => {

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -63,7 +63,7 @@ export class DijkstraSinglePath implements PathStrategy {
         const path: Path = [len - 1];
 
         // Until we visit the source and have more nodes
-        while (path[path.length - 1] && visitQueue.length > 0) {
+        while (path[path.length - 1] !== 0 && visitQueue.length > 0) {
             const currentNode = visitQueue.pop()!;
 
             visited[currentNode] = true;
@@ -83,7 +83,7 @@ export class DijkstraSinglePath implements PathStrategy {
             }
 
             if (nextIndex < 0) {
-                throw new Error('DijkstraSinglePath::findMaxCost : Cycle detected');
+                throw new Error('DijkstraSinglePath::findMaxCost : Disconnected graph');
             }
 
             visitQueue.push(nextIndex);

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -8,7 +8,12 @@ export class DijkstraSinglePath implements PathStrategy {
     findPaths(isomorph: GraphIsomorph): IterableIterator<Path> {
         const paths: Path[] = [];
 
+        paths.push([]);
+
         return paths.values();
     }
 
+    static create(): DijkstraSinglePath {
+        return new DijkstraSinglePath();
+    }
 }

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -1,16 +1,103 @@
 import {
+    AdjacencyMatrix,
+    AdjacencyMatrixBuilder,
     GraphIsomorph,
     Path,
     PathStrategy,
 } from '../';
 
 export class DijkstraSinglePath implements PathStrategy {
+    private generateCostArray(isomorph: GraphIsomorph): number[] {
+        const lenNodes = isomorph.getNumberNodes();
+
+        const visitQueue: number[] = [0];
+        const visited: boolean[] = new Array(lenNodes).fill(false);
+        const cost: number[] = new Array(lenNodes).fill(-1);
+        cost[0] = 0;
+        let found = false;
+
+        const recurse = (index: number): void => {
+            const costToIndex = cost[index];
+            for (let i = 0; i < lenNodes; i++) {
+                // If node is a cycle, skip
+                if (visited[i] === true || i === index) {
+                    continue;
+                }
+
+                const previousCost = cost[i];
+                const costToNode = isomorph.getEdge(index, i).getScore();
+
+                // TODO: WHat if they are equal? Ambiguous case
+                if (costToNode > 0 && costToIndex + costToNode > costToIndex) {
+                    cost[i] = costToIndex + costToNode;
+                    visitQueue.push(i);
+                }
+            }
+        };
+
+        while (!found && visitQueue.length > 0) {
+            const index: number = visitQueue.pop()!;
+
+            if (visited[index]) {
+                continue;
+            }
+
+            visited[index] = true;
+            recurse(index);
+
+            found = cost[lenNodes - 1] > 0;
+        }
+
+        if (!found) {
+            throw new Error('ERROR: DijkstraSinglePath: Path not found');
+        }
+
+        return cost;
+    }
+
+    private findMaxCostPath(costArray: number[]): Path {
+        const len = costArray.length;
+        const visited: boolean[] = new Array(len).fill(false);
+        const visitQueue: number[] = [len - 1];
+
+        const path: Path = [len - 1];
+
+        // Until we visit the source and have more nodes
+        while (path[path.length - 1] && visitQueue.length > 0) {
+            const currentNode = visitQueue.pop()!;
+
+            visited[currentNode] = true;
+
+            let nextIndex = -1;
+            let maxScore = -1;
+
+            for (let i = 0; i < len; i++) {
+                if (visited[i]) {
+                    continue;
+                }
+
+                if (costArray[i] > maxScore) {
+                    nextIndex = i;
+                    maxScore = costArray[i];
+                }
+            }
+
+            if (nextIndex < 0) {
+                throw new Error('DijkstraSinglePath::findMaxCost : Cycle detected');
+            }
+
+            visitQueue.push(nextIndex);
+            path.push(nextIndex);
+        }
+
+        return path.reverse();
+    }
+
     findPaths(isomorph: GraphIsomorph): IterableIterator<Path> {
-        const paths: Path[] = [];
+        const costArray = this.generateCostArray(isomorph);
+        const path = this.findMaxCostPath(costArray);
 
-        paths.push([]);
-
-        return paths.values();
+        return [path].values();
     }
 
     static create(): DijkstraSinglePath {

--- a/src/pathStrategy/dijkstraSingle.ts
+++ b/src/pathStrategy/dijkstraSingle.ts
@@ -7,19 +7,23 @@ import {
 } from '../';
 
 export class DijkstraSinglePath implements PathStrategy {
-    private generateCostArray(isomorph: GraphIsomorph): number[] {
+    // Finds max cost to each path from source (node zero)
+    private generateMaxCostArray(isomorph: GraphIsomorph): number[] {
         const lenNodes = isomorph.getNumberNodes();
 
         const visitQueue: number[] = [0];
         const visited: boolean[] = new Array(lenNodes).fill(false);
         const cost: number[] = new Array(lenNodes).fill(-1);
+
         cost[0] = 0;
         let found = false;
 
-        const recurse = (index: number): void => {
+        // Bredth-first helper
+        const searchNeighbors = (index: number): void => {
             const costToIndex = cost[index];
+
             for (let i = 0; i < lenNodes; i++) {
-                // If node is a cycle, skip
+                // If node at i causes a cycle, skip
                 if (visited[i] === true || i === index) {
                     continue;
                 }
@@ -35,6 +39,7 @@ export class DijkstraSinglePath implements PathStrategy {
             }
         };
 
+        // Search while we still have more candidates to inspect
         while (!found && visitQueue.length > 0) {
             const index: number = visitQueue.pop()!;
 
@@ -43,7 +48,7 @@ export class DijkstraSinglePath implements PathStrategy {
             }
 
             visited[index] = true;
-            recurse(index);
+            searchNeighbors(index);
 
             found = cost[lenNodes - 1] > 0;
         }
@@ -55,6 +60,8 @@ export class DijkstraSinglePath implements PathStrategy {
         return cost;
     }
 
+    // From max cost to each node from source, find max cost from source to sink
+    // The source is always node zero and the sink is always the last node
     private findMaxCostPath(costArray: number[]): Path {
         const len = costArray.length;
         const visited: boolean[] = new Array(len).fill(false);
@@ -62,7 +69,7 @@ export class DijkstraSinglePath implements PathStrategy {
 
         const path: Path = [len - 1];
 
-        // Until we visit the source and have more nodes
+        // Until we visit the source and have more nodes to visit
         while (path[path.length - 1] !== 0 && visitQueue.length > 0) {
             const currentNode = visitQueue.pop()!;
 
@@ -94,7 +101,7 @@ export class DijkstraSinglePath implements PathStrategy {
     }
 
     findPaths(isomorph: GraphIsomorph): IterableIterator<Path> {
-        const costArray = this.generateCostArray(isomorph);
+        const costArray = this.generateMaxCostArray(isomorph);
         const path = this.findMaxCostPath(costArray);
 
         return [path].values();

--- a/src/pathStrategy/index.ts
+++ b/src/pathStrategy/index.ts
@@ -1,0 +1,1 @@
+export * from './dijkstraSingle';

--- a/src/tests/adjMatrixBuilder.test.ts
+++ b/src/tests/adjMatrixBuilder.test.ts
@@ -28,6 +28,7 @@ describe('AdjacencyMatrixBuilder', () => {
 
         expect(adjMatrix.getNode(numberOfNodes - 1).kind).toEqual(TESTTOKEN);
         expect(() => {
+            /* tslint:disable-next-line:no-unused-expression */
             adjMatrix.getNode(numberOfNodes).kind
         }).toThrow(Error);
     });
@@ -42,6 +43,7 @@ describe('AdjacencyMatrixBuilder', () => {
 
         expect(adjMatrix.getNode(numberOfNodes - 1).kind).toEqual(TESTTOKEN);
         expect(() => {
+            /* tslint:disable-next-line:no-unused-expression */
             adjMatrix.getNode(numberOfNodes).kind
         }).toThrow(Error);
     });
@@ -56,6 +58,7 @@ describe('AdjacencyMatrixBuilder', () => {
 
         expect(adjMatrix.getNode(numberOfNodes - 1).kind).toEqual(TESTTOKEN);
         expect(() => {
+            /* tslint:disable-next-line:no-unused-expression */
             adjMatrix.getNode(numberOfNodes).kind
         }).toThrow(Error);
     });

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -1,7 +1,7 @@
 import {
     AdjacencyMatrix,
     AdjacencyMatrixBuilder,
-    DijkstraSinglePath,
+    DijkstraLongestPath,
     Path,
     Edge,
 } from '../';
@@ -11,7 +11,7 @@ import {
     tokenGenerator,
 } from './resources';
 
-describe('DijkstraSinglePath', () => {
+describe('DijkstraLongestPath', () => {
     it('Picks the best path', () => {
         const adjMatrix = AdjacencyMatrixBuilder
             .newBuilder()
@@ -25,7 +25,7 @@ describe('DijkstraSinglePath', () => {
 
         const knownBestPath: Path = [0, 1, 2];
 
-        const pathStrategy = DijkstraSinglePath.create();
+        const pathStrategy = DijkstraLongestPath.create();
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
@@ -48,7 +48,7 @@ describe('DijkstraSinglePath', () => {
 
         const knownBestPath: Path = [0, 2, 1, 3];
 
-        const pathStrategy = DijkstraSinglePath.create();
+        const pathStrategy = DijkstraLongestPath.create();
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
@@ -71,7 +71,7 @@ describe('DijkstraSinglePath', () => {
 
         const knownBestPath: Path = [0, 2, 3];
 
-        const pathStrategy = DijkstraSinglePath.create();
+        const pathStrategy = DijkstraLongestPath.create();
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
@@ -96,7 +96,7 @@ describe('DijkstraSinglePath', () => {
 
         const knownBestPath: Path = [0, 3, 5];
 
-        const pathStrategy = DijkstraSinglePath.create();
+        const pathStrategy = DijkstraLongestPath.create();
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
@@ -116,7 +116,7 @@ describe('DijkstraSinglePath', () => {
             ]))
             .build();
 
-        const pathStrategy = DijkstraSinglePath.create();
+        const pathStrategy = DijkstraLongestPath.create();
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -57,6 +57,54 @@ describe('DijkstraSinglePath', () => {
         expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
     });
 
+    it('Picks best path among options', () => {
+        const adjMatrix = AdjacencyMatrixBuilder
+            .newBuilder()
+            .withNodes(tokenGenerator(4))
+            .withEdges(Edge.getMatrixFromScoreMatrix([
+                [0, 1, 3, 0],
+                [0, 0, 1, 1],
+                [0, 0, 0, 2],
+                [0, 0, 0, 0]
+            ]))
+            .build();
+
+        const knownBestPath: Path = [0, 2, 3];
+
+        const pathStrategy = DijkstraSinglePath.create();
+
+        const pathIterator = pathStrategy.findPaths(adjMatrix);
+
+        const bestPath = pathIterator.next().value;
+
+        expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
+    });
+
+    it('Picks best path among more options', () => {
+        const adjMatrix = AdjacencyMatrixBuilder
+            .newBuilder()
+            .withNodes(tokenGenerator(6))
+            .withEdges(Edge.getMatrixFromScoreMatrix([
+                [ 0,  1, 33, 98,  0,  0],
+                [ 0,  0,  0,  3,  0,  1],
+                [ 0,  0,  0,  0, 17,  0],
+                [ 0,  0,  0,  0,  0,  1],
+                [ 0,  0,  0,  0,  0,  1],
+                [ 0,  0,  0,  0,  0,  0]
+            ]))
+            .build();
+
+        const knownBestPath: Path = [0, 3, 5];
+
+        const pathStrategy = DijkstraSinglePath.create();
+
+        const pathIterator = pathStrategy.findPaths(adjMatrix);
+
+        const bestPath = pathIterator.next().value;
+
+        expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
+    });
+
     it('Only picks one path', () => {
         const adjMatrix = AdjacencyMatrixBuilder
             .newBuilder()

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -23,7 +23,7 @@ describe('DijkstraSinglePath', () => {
             ]))
             .build();
 
-        const knownBestPath: Path = [1, 2, 3];
+        const knownBestPath: Path = [0, 1, 2];
 
         const pathStrategy = DijkstraSinglePath.create();
 
@@ -46,7 +46,7 @@ describe('DijkstraSinglePath', () => {
             ]))
             .build();
 
-        const knownBestPath: Path = [1, 3, 2, 4];
+        const knownBestPath: Path = [0, 2, 1, 3];
 
         const pathStrategy = DijkstraSinglePath.create();
 

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -35,6 +35,26 @@ describe('DijkstraSinglePath', () => {
     });
 
     it('Picks best path, again', () => {
+        const adjMatrix = AdjacencyMatrixBuilder
+            .newBuilder()
+            .withNodes(tokenGenerator(4))
+            .withEdges(Edge.getMatrixFromScoreMatrix([
+                [0, 0, 1, 0],
+                [0, 0, 0, 1],
+                [0, 1, 0, 0],
+                [0, 0, 0, 0]
+            ]))
+            .build();
+
+        const knownBestPath: Path = [1, 3, 2, 4];
+
+        const pathStrategy = DijkstraSinglePath.create();
+
+        const pathIterator = pathStrategy.findPaths(adjMatrix);
+
+        const bestPath = pathIterator.next().value;
+
+        expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
     });
 
     it('Only picks one path', () => {
@@ -52,7 +72,7 @@ describe('DijkstraSinglePath', () => {
 
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
-        expect(pathIterator.next()).toBeDefined();
-        expect(pathIterator.next()).toBeUndefined();
+        expect(pathIterator.next().value).toBeDefined();
+        expect(pathIterator.next().value).toBeUndefined();
     });
 });

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -30,14 +30,29 @@ describe('DijkstraSinglePath', () => {
         const pathIterator = pathStrategy.findPaths(adjMatrix);
 
         const bestPath = pathIterator.next().value;
-        console.log(bestPath);
 
         expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
     });
 
-    it('Only picks one path', () => {
+    it('Picks best path, again', () => {
     });
 
-    it('', () => {
+    it('Only picks one path', () => {
+        const adjMatrix = AdjacencyMatrixBuilder
+            .newBuilder()
+            .withNodes(tokenGenerator(3))
+            .withEdges(Edge.getMatrixFromScoreMatrix([
+                [0, 1, 0],
+                [0, 0, 1],
+                [0, 0, 0]
+            ]))
+            .build();
+
+        const pathStrategy = DijkstraSinglePath.create();
+
+        const pathIterator = pathStrategy.findPaths(adjMatrix);
+
+        expect(pathIterator.next()).toBeDefined();
+        expect(pathIterator.next()).toBeUndefined();
     });
 });

--- a/src/tests/dijkstraSingle.test.ts
+++ b/src/tests/dijkstraSingle.test.ts
@@ -1,0 +1,43 @@
+import {
+    AdjacencyMatrix,
+    AdjacencyMatrixBuilder,
+    DijkstraSinglePath,
+    Path,
+    Edge,
+} from '../';
+
+import {
+    isEqualPaths,
+    tokenGenerator,
+} from './resources';
+
+describe('DijkstraSinglePath', () => {
+    it('Picks the best path', () => {
+        const adjMatrix = AdjacencyMatrixBuilder
+            .newBuilder()
+            .withNodes(tokenGenerator(3))
+            .withEdges(Edge.getMatrixFromScoreMatrix([
+                [0, 1, 0],
+                [0, 0, 1],
+                [0, 0, 0]
+            ]))
+            .build();
+
+        const knownBestPath: Path = [1, 2, 3];
+
+        const pathStrategy = DijkstraSinglePath.create();
+
+        const pathIterator = pathStrategy.findPaths(adjMatrix);
+
+        const bestPath = pathIterator.next().value;
+        console.log(bestPath);
+
+        expect(isEqualPaths(bestPath, knownBestPath)).toBeTruthy();
+    });
+
+    it('Only picks one path', () => {
+    });
+
+    it('', () => {
+    });
+});

--- a/src/tests/resources/shared.ts
+++ b/src/tests/resources/shared.ts
@@ -1,7 +1,9 @@
 import {
     AdjacencyMatrix,
     Edge,
+    Path,
 } from '../../';
+
 import {
     generateId,
 } from '../../utils';
@@ -17,7 +19,19 @@ import {
     TestToken,
     TestTokenOpts,
     testTokenFactoryDetails,
-}from './testToken';
+} from './testToken';
+
+export const isEqualPaths = (a: Path, b: Path): boolean => {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+
+    return true;
+}
 
 export const isZeroMatrix = (adjMatrix: AdjacencyMatrix): boolean => {
     const length = adjMatrix.getNumberNodes();


### PR DESCRIPTION
Tweak Dijkstra's Algorithm to find longest path, as a PathStrategy. Returns the single "best" (max) path through the Graph as an Iterator.

This PR also contains some general clean-up